### PR TITLE
Replace matplotlib 'left=' with 'x='

### DIFF
--- a/01_inspecting.ipynb
+++ b/01_inspecting.ipynb
@@ -231,7 +231,7 @@
     }
    ],
    "source": [
-    "plt.bar(left=years_since_1940, height=nr_papers_since_1940, width=1.0)\n",
+    "plt.bar(x=years_since_1940, height=nr_papers_since_1940, width=1.0)\n",
     "plt.xlim(1940, 2018)\n",
     "plt.xlabel('year')\n",
     "plt.ylabel('number of papers');"


### PR DESCRIPTION
The 'left' option for plt.bar has been deprecated in favor of 'x' and will no longer be supported starting from Matplotlib 3.0. The warning that appears when still using 'left' is the following (it disappears when replacing it with 'x'):

```
c:\python35\lib\site-packages\matplotlib\__init__.py:1710: MatplotlibDeprecationWarning: The *left* kwarg to `bar` is deprecated use *x* instead. Support for *left* will be removed in Matplotlib 3.0
  return func(ax, *args, **kwargs)
```